### PR TITLE
Add ds-policy-engine and ds-policy-engine-ui deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This repository contains GitOps configurations for deploying and managing DS mic
 - **Frontend**
   The frontend is the user interface of the NextGen Node that allows users to access and interact with its features.
 
+- **Policy Engine**
+  Standalone policy-as-code microservice (FastAPI + OPA). Evaluates user permissions based on role and institute. Repo: [ds-policy-engine](https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine).
+
+- **Policy Engine UI**
+  Static web UI for the Policy Engine (nginx). Repo: [ds-policy-engine-ui](https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine-ui).
+
 ## Structure
 
 - Each service has its own directory containing a `fleet.yaml` file and related Helm values.

--- a/hus-services/policy-engine-ui/fleet.yaml
+++ b/hus-services/policy-engine-ui/fleet.yaml
@@ -1,0 +1,11 @@
+defaultNamespace: hus
+dependsOn:
+  - name: nextgen-gitops-hus-services-policy-engine
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
+  chart: ds-policy-engine-ui
+  releaseName: ds-policy-engine-ui
+  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/hus-services/policy-engine-ui/fleet.yaml
+++ b/hus-services/policy-engine-ui/fleet.yaml
@@ -5,8 +5,7 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version once you want reproducible rollouts.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
+  version: 0.1.0-dev.11.develop.3c2ccdb0
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine-ui/fleet.yaml
+++ b/hus-services/policy-engine-ui/fleet.yaml
@@ -5,7 +5,8 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version once you want reproducible rollouts.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine-ui/values.yaml
+++ b/hus-services/policy-engine-ui/values.yaml
@@ -7,4 +7,4 @@ ingress:
   host: ds-policy-engine-ui.hus.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: http://ds-policy-engine.hus.nextgen.hiro-develop.nl
+  apiBaseUrl: https://ds-policy-engine.hus.nextgen.hiro-develop.nl

--- a/hus-services/policy-engine-ui/values.yaml
+++ b/hus-services/policy-engine-ui/values.yaml
@@ -1,0 +1,10 @@
+namespace: hus
+
+nodeSelector:
+  role: hus
+
+ingress:
+  host: ds-policy-engine-ui.hus.nextgen.hiro-develop.nl
+
+config:
+  apiBaseUrl: http://ds-policy-engine.hus.nextgen.hiro-develop.nl

--- a/hus-services/policy-engine-ui/values.yaml
+++ b/hus-services/policy-engine-ui/values.yaml
@@ -4,7 +4,12 @@ nodeSelector:
   role: hus
 
 ingress:
+  # Fully internal — UI reachable only via kubectl port-forward:
+  #   kubectl -n hus port-forward svc/ds-policy-engine-ui 8080:80
+  enabled: false
   host: ds-policy-engine-ui.hus.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: https://ds-policy-engine.hus.nextgen.hiro-develop.nl
+  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
+  # browser /api/ calls to this address — no public URL exposed.
+  apiBaseUrl: http://ds-policy-engine:8000

--- a/hus-services/policy-engine-ui/values.yaml
+++ b/hus-services/policy-engine-ui/values.yaml
@@ -4,17 +4,15 @@ nodeSelector:
   role: hus
 
 ingress:
-  # Fully internal — UI reachable only via kubectl port-forward:
-  #   kubectl -n hus port-forward svc/ds-policy-engine-ui 8080:80
-  enabled: false
+  # TEMP: enabled while there's no sensitive data and no shared gateway yet.
+  # Flip to false once ds-gateway fronts the UI.
+  enabled: true
   host: ds-policy-engine-ui.hus.nextgen.hiro-develop.nl
 
 backend:
-  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
-  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  # Option B: UI's in-pod nginx reverse-proxies /api, /health, /docs to this
+  # URL. Same-namespace short name resolves via Kubernetes DNS inside the pod.
   url: http://ds-policy-engine:8000
 
-# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
-# want the browser to call a different backend directly, bypassing the proxy.
-config:
-  apiBaseUrl: ""
+# config.apiBaseUrl is intentionally omitted — chart default "" means
+# same-origin via nginx proxy, which is what every site wants today.

--- a/hus-services/policy-engine-ui/values.yaml
+++ b/hus-services/policy-engine-ui/values.yaml
@@ -9,7 +9,12 @@ ingress:
   enabled: false
   host: ds-policy-engine-ui.hus.nextgen.hiro-develop.nl
 
+backend:
+  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
+  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  url: http://ds-policy-engine:8000
+
+# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
+# want the browser to call a different backend directly, bypassing the proxy.
 config:
-  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
-  # browser /api/ calls to this address — no public URL exposed.
-  apiBaseUrl: http://ds-policy-engine:8000
+  apiBaseUrl: ""

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -1,0 +1,9 @@
+defaultNamespace: hus
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
+  chart: ds-policy-engine
+  releaseName: ds-policy-engine
+  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -3,8 +3,7 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version once you want reproducible rollouts.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
+  version: 0.1.0-dev.15.develop.646f7754
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -3,7 +3,8 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version once you want reproducible rollouts.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.15.develop.646f7754
+  version: 0.1.0-dev.31.develop.2274bc55
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -4,6 +4,9 @@ nodeSelector:
   role: hus
 
 ingress:
+  # Fully internal — backend reachable only by in-cluster DNS
+  # (ds-policy-engine.hus.svc.cluster.local:8000).
+  enabled: false
   host: ds-policy-engine.hus.nextgen.hiro-develop.nl
 
 cors:

--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -4,20 +4,24 @@ nodeSelector:
   role: hus
 
 ingress:
-  # Fully internal — backend reachable only by in-cluster DNS
-  # (ds-policy-engine.hus.svc.cluster.local:8000).
-  enabled: false
+  # TEMP: enabled for now while there's no sensitive data and no shared
+  # gateway yet. Flip to false once ds-gateway fronts the service.
+  enabled: true
   host: ds-policy-engine.hus.nextgen.hiro-develop.nl
 
-# Option B: UI talks to backend same-origin via its nginx proxy — no browser
-# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
-# a knob in case a second UI/client origin ever needs direct access.
+# With Option B the UI calls the backend same-origin through its nginx proxy,
+# so no browser ever hits this backend directly and CORS is not needed.
 cors:
   allowedOrigins: ""
 
+# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
+# Flip to true on dev sites if you want to poke the API from a browser.
 docs:
   enabled: false
 
+# OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
+# and evaluates the compiled Rego rules at request time. Keep on — the
+# backend depends on it.
 opa:
   enabled: true
 
@@ -27,4 +31,4 @@ persistence:
 
 env:
   logLevel: INFO
-  nodeName: hus
+  # DS__NODE_NAME intentionally omitted — chart defaults it to the namespace.

--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -1,0 +1,24 @@
+namespace: hus
+
+nodeSelector:
+  role: hus
+
+ingress:
+  host: ds-policy-engine.hus.nextgen.hiro-develop.nl
+
+cors:
+  allowedOrigins: "http://ds-policy-engine-ui.hus.nextgen.hiro-develop.nl"
+
+docs:
+  enabled: false
+
+opa:
+  enabled: true
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+env:
+  logLevel: INFO
+  nodeName: hus

--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -9,8 +9,11 @@ ingress:
   enabled: false
   host: ds-policy-engine.hus.nextgen.hiro-develop.nl
 
+# Option B: UI talks to backend same-origin via its nginx proxy — no browser
+# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
+# a knob in case a second UI/client origin ever needs direct access.
 cors:
-  allowedOrigins: "https://ds-policy-engine-ui.hus.nextgen.hiro-develop.nl"
+  allowedOrigins: ""
 
 docs:
   enabled: false

--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -7,7 +7,7 @@ ingress:
   host: ds-policy-engine.hus.nextgen.hiro-develop.nl
 
 cors:
-  allowedOrigins: "http://ds-policy-engine-ui.hus.nextgen.hiro-develop.nl"
+  allowedOrigins: "https://ds-policy-engine-ui.hus.nextgen.hiro-develop.nl"
 
 docs:
   enabled: false

--- a/ki-services/policy-engine-ui/fleet.yaml
+++ b/ki-services/policy-engine-ui/fleet.yaml
@@ -1,0 +1,11 @@
+defaultNamespace: ki
+dependsOn:
+  - name: nextgen-gitops-ki-services-policy-engine
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
+  chart: ds-policy-engine-ui
+  releaseName: ds-policy-engine-ui
+  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/ki-services/policy-engine-ui/fleet.yaml
+++ b/ki-services/policy-engine-ui/fleet.yaml
@@ -5,7 +5,8 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version once you want reproducible rollouts.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine-ui/fleet.yaml
+++ b/ki-services/policy-engine-ui/fleet.yaml
@@ -5,8 +5,9 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version once you want reproducible rollouts.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — Fleet only rolls out when this string changes. Bump deliberately
+  # when promoting a new UI build (grab from
+  # https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts/index.yaml).
+  version: 0.1.0-dev.11.develop.3c2ccdb0
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine-ui/values.yaml
+++ b/ki-services/policy-engine-ui/values.yaml
@@ -1,0 +1,10 @@
+namespace: ki
+
+nodeSelector:
+  role: ki
+
+ingress:
+  host: ds-policy-engine-ui.ki.nextgen.hiro-develop.nl
+
+config:
+  apiBaseUrl: http://ds-policy-engine.ki.nextgen.hiro-develop.nl

--- a/ki-services/policy-engine-ui/values.yaml
+++ b/ki-services/policy-engine-ui/values.yaml
@@ -7,4 +7,4 @@ ingress:
   host: ds-policy-engine-ui.ki.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: http://ds-policy-engine.ki.nextgen.hiro-develop.nl
+  apiBaseUrl: https://ds-policy-engine.ki.nextgen.hiro-develop.nl

--- a/ki-services/policy-engine-ui/values.yaml
+++ b/ki-services/policy-engine-ui/values.yaml
@@ -4,17 +4,16 @@ nodeSelector:
   role: ki
 
 ingress:
-  # Fully internal — UI reachable only via kubectl port-forward:
-  #   kubectl -n ki port-forward svc/ds-policy-engine-ui 8080:80
-  enabled: false
+  # TEMP: enabled while there's no sensitive data and no shared gateway yet.
+  # Flip to false once ds-gateway fronts the UI.
+  enabled: true
   host: ds-policy-engine-ui.ki.nextgen.hiro-develop.nl
 
 backend:
-  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
-  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  # Option B: UI's in-pod nginx reverse-proxies /api, /health, /docs to this
+  # URL. Same-namespace short name resolves via Kubernetes DNS inside the pod
+  # — no public backend URL is ever exposed to the browser.
   url: http://ds-policy-engine:8000
 
-# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
-# want the browser to call a different backend directly, bypassing the proxy.
-config:
-  apiBaseUrl: ""
+# config.apiBaseUrl is intentionally omitted — the chart default is "" which
+# means "same-origin via nginx proxy", which is what every site wants today.

--- a/ki-services/policy-engine-ui/values.yaml
+++ b/ki-services/policy-engine-ui/values.yaml
@@ -4,7 +4,12 @@ nodeSelector:
   role: ki
 
 ingress:
+  # Fully internal — UI reachable only via kubectl port-forward:
+  #   kubectl -n ki port-forward svc/ds-policy-engine-ui 8080:80
+  enabled: false
   host: ds-policy-engine-ui.ki.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: https://ds-policy-engine.ki.nextgen.hiro-develop.nl
+  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
+  # browser /api/ calls to this address — no public URL exposed.
+  apiBaseUrl: http://ds-policy-engine:8000

--- a/ki-services/policy-engine-ui/values.yaml
+++ b/ki-services/policy-engine-ui/values.yaml
@@ -9,7 +9,12 @@ ingress:
   enabled: false
   host: ds-policy-engine-ui.ki.nextgen.hiro-develop.nl
 
+backend:
+  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
+  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  url: http://ds-policy-engine:8000
+
+# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
+# want the browser to call a different backend directly, bypassing the proxy.
 config:
-  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
-  # browser /api/ calls to this address — no public URL exposed.
-  apiBaseUrl: http://ds-policy-engine:8000
+  apiBaseUrl: ""

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -3,7 +3,9 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version (e.g. 0.1.0-dev.N.develop.XXXXXXXX) once you want
+  # reproducible rollouts — same convention as the catalog service.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -1,0 +1,9 @@
+defaultNamespace: ki
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
+  chart: ds-policy-engine
+  releaseName: ds-policy-engine
+  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -7,6 +7,6 @@ helm:
   # when promoting a new build to this site (grab the version from
   # https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts/index.yaml
   # or https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine/releases).
-  version: 0.1.0-dev.15.develop.646f7754
+  version: 0.1.0-dev.31.develop.2274bc55
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -3,9 +3,10 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version (e.g. 0.1.0-dev.N.develop.XXXXXXXX) once you want
-  # reproducible rollouts — same convention as the catalog service.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — Fleet only rolls out when this string changes. Bump deliberately
+  # when promoting a new build to this site (grab the version from
+  # https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts/index.yaml
+  # or https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine/releases).
+  version: 0.1.0-dev.15.develop.646f7754
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -7,7 +7,7 @@ ingress:
   host: ds-policy-engine.ki.nextgen.hiro-develop.nl
 
 cors:
-  allowedOrigins: "http://ds-policy-engine-ui.ki.nextgen.hiro-develop.nl"
+  allowedOrigins: "https://ds-policy-engine-ui.ki.nextgen.hiro-develop.nl"
 
 docs:
   enabled: false

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -4,6 +4,9 @@ nodeSelector:
   role: ki
 
 ingress:
+  # Fully internal — backend reachable only by in-cluster DNS
+  # (ds-policy-engine.ki.svc.cluster.local:8000).
+  enabled: false
   host: ds-policy-engine.ki.nextgen.hiro-develop.nl
 
 cors:

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -9,8 +9,11 @@ ingress:
   enabled: false
   host: ds-policy-engine.ki.nextgen.hiro-develop.nl
 
+# Option B: UI talks to backend same-origin via its nginx proxy — no browser
+# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
+# a knob in case a second UI/client origin ever needs direct access.
 cors:
-  allowedOrigins: "https://ds-policy-engine-ui.ki.nextgen.hiro-develop.nl"
+  allowedOrigins: ""
 
 docs:
   enabled: false

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -1,0 +1,24 @@
+namespace: ki
+
+nodeSelector:
+  role: ki
+
+ingress:
+  host: ds-policy-engine.ki.nextgen.hiro-develop.nl
+
+cors:
+  allowedOrigins: "http://ds-policy-engine-ui.ki.nextgen.hiro-develop.nl"
+
+docs:
+  enabled: false
+
+opa:
+  enabled: true
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+env:
+  logLevel: INFO
+  nodeName: ki

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -4,20 +4,26 @@ nodeSelector:
   role: ki
 
 ingress:
-  # Fully internal — backend reachable only by in-cluster DNS
-  # (ds-policy-engine.ki.svc.cluster.local:8000).
-  enabled: false
+  # TEMP: enabled for now while there's no sensitive data and no shared
+  # gateway yet. Flip to false once ds-gateway fronts the service (or any
+  # time we need to make policy-engine fully internal).
+  enabled: true
   host: ds-policy-engine.ki.nextgen.hiro-develop.nl
 
-# Option B: UI talks to backend same-origin via its nginx proxy — no browser
-# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
-# a knob in case a second UI/client origin ever needs direct access.
+# With Option B the UI calls the backend same-origin through its nginx proxy,
+# so no browser ever hits this backend directly and CORS is not needed. Kept
+# as an explicit empty knob in case a second origin ever needs direct access.
 cors:
   allowedOrigins: ""
 
+# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
+# Flip to true on dev sites if you want to poke the API from a browser.
 docs:
   enabled: false
 
+# OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
+# and evaluates the compiled Rego rules at request time. Keep on — the
+# backend depends on it.
 opa:
   enabled: true
 
@@ -27,4 +33,5 @@ persistence:
 
 env:
   logLevel: INFO
-  nodeName: ki
+  # DS__NODE_NAME intentionally omitted — the chart defaults it to the
+  # release namespace (ki/hus/uva), so setting it here would duplicate.

--- a/uva-services/policy-engine-ui/fleet.yaml
+++ b/uva-services/policy-engine-ui/fleet.yaml
@@ -5,8 +5,7 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version once you want reproducible rollouts.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
+  version: 0.1.0-dev.11.develop.3c2ccdb0
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine-ui/fleet.yaml
+++ b/uva-services/policy-engine-ui/fleet.yaml
@@ -5,7 +5,8 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
-  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version once you want reproducible rollouts.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine-ui/fleet.yaml
+++ b/uva-services/policy-engine-ui/fleet.yaml
@@ -1,0 +1,11 @@
+defaultNamespace: uva
+dependsOn:
+  - name: nextgen-gitops-uva-services-policy-engine
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts
+  chart: ds-policy-engine-ui
+  releaseName: ds-policy-engine-ui
+  # TODO: bump to the actual chart version after ds-policy-engine-ui CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/uva-services/policy-engine-ui/values.yaml
+++ b/uva-services/policy-engine-ui/values.yaml
@@ -1,0 +1,10 @@
+namespace: uva
+
+nodeSelector:
+  role: uva
+
+ingress:
+  host: ds-policy-engine-ui.uva.nextgen.hiro-develop.nl
+
+config:
+  apiBaseUrl: http://ds-policy-engine.uva.nextgen.hiro-develop.nl

--- a/uva-services/policy-engine-ui/values.yaml
+++ b/uva-services/policy-engine-ui/values.yaml
@@ -4,17 +4,15 @@ nodeSelector:
   role: uva
 
 ingress:
-  # Fully internal — UI reachable only via kubectl port-forward:
-  #   kubectl -n uva port-forward svc/ds-policy-engine-ui 8080:80
-  enabled: false
+  # TEMP: enabled while there's no sensitive data and no shared gateway yet.
+  # Flip to false once ds-gateway fronts the UI.
+  enabled: true
   host: ds-policy-engine-ui.uva.nextgen.hiro-develop.nl
 
 backend:
-  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
-  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  # Option B: UI's in-pod nginx reverse-proxies /api, /health, /docs to this
+  # URL. Same-namespace short name resolves via Kubernetes DNS inside the pod.
   url: http://ds-policy-engine:8000
 
-# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
-# want the browser to call a different backend directly, bypassing the proxy.
-config:
-  apiBaseUrl: ""
+# config.apiBaseUrl is intentionally omitted — chart default "" means
+# same-origin via nginx proxy, which is what every site wants today.

--- a/uva-services/policy-engine-ui/values.yaml
+++ b/uva-services/policy-engine-ui/values.yaml
@@ -7,4 +7,4 @@ ingress:
   host: ds-policy-engine-ui.uva.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: http://ds-policy-engine.uva.nextgen.hiro-develop.nl
+  apiBaseUrl: https://ds-policy-engine.uva.nextgen.hiro-develop.nl

--- a/uva-services/policy-engine-ui/values.yaml
+++ b/uva-services/policy-engine-ui/values.yaml
@@ -4,7 +4,12 @@ nodeSelector:
   role: uva
 
 ingress:
+  # Fully internal — UI reachable only via kubectl port-forward:
+  #   kubectl -n uva port-forward svc/ds-policy-engine-ui 8080:80
+  enabled: false
   host: ds-policy-engine-ui.uva.nextgen.hiro-develop.nl
 
 config:
-  apiBaseUrl: https://ds-policy-engine.uva.nextgen.hiro-develop.nl
+  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
+  # browser /api/ calls to this address — no public URL exposed.
+  apiBaseUrl: http://ds-policy-engine:8000

--- a/uva-services/policy-engine-ui/values.yaml
+++ b/uva-services/policy-engine-ui/values.yaml
@@ -9,7 +9,12 @@ ingress:
   enabled: false
   host: ds-policy-engine-ui.uva.nextgen.hiro-develop.nl
 
+backend:
+  # Option B: UI's nginx reverse-proxies /api, /health, /docs to this URL.
+  # Same-namespace short name resolves via Kubernetes DNS inside the pod.
+  url: http://ds-policy-engine:8000
+
+# Keep empty — Option B uses same-origin. Set to an absolute URL only if you
+# want the browser to call a different backend directly, bypassing the proxy.
 config:
-  # In-cluster DNS (same-namespace short name). The UI's nginx forwards
-  # browser /api/ calls to this address — no public URL exposed.
-  apiBaseUrl: http://ds-policy-engine:8000
+  apiBaseUrl: ""

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -3,8 +3,7 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
-  # Pin to an exact version once you want reproducible rollouts.
-  version: ">=0.1.0-0 <0.2.0"
+  # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
+  version: 0.1.0-dev.15.develop.646f7754
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -3,7 +3,8 @@ helm:
   repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
   chart: ds-policy-engine
   releaseName: ds-policy-engine
-  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
-  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  # Semver range matching any published 0.1.x chart (stable or -dev prerelease).
+  # Pin to an exact version once you want reproducible rollouts.
+  version: ">=0.1.0-0 <0.2.0"
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -1,0 +1,9 @@
+defaultNamespace: uva
+helm:
+  repo: https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts
+  chart: ds-policy-engine
+  releaseName: ds-policy-engine
+  # TODO: bump to the actual chart version after ds-policy-engine CI publishes it to gh-pages.
+  version: 0.1.0-dev.0.develop.PLACEHOLDER
+  valuesFiles:
+    - values.yaml

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.15.develop.646f7754
+  version: 0.1.0-dev.31.develop.2274bc55
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -7,7 +7,7 @@ ingress:
   host: ds-policy-engine.uva.nextgen.hiro-develop.nl
 
 cors:
-  allowedOrigins: "http://ds-policy-engine-ui.uva.nextgen.hiro-develop.nl"
+  allowedOrigins: "https://ds-policy-engine-ui.uva.nextgen.hiro-develop.nl"
 
 docs:
   enabled: false

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -1,0 +1,24 @@
+namespace: uva
+
+nodeSelector:
+  role: uva
+
+ingress:
+  host: ds-policy-engine.uva.nextgen.hiro-develop.nl
+
+cors:
+  allowedOrigins: "http://ds-policy-engine-ui.uva.nextgen.hiro-develop.nl"
+
+docs:
+  enabled: false
+
+opa:
+  enabled: true
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+env:
+  logLevel: INFO
+  nodeName: uva

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -9,8 +9,11 @@ ingress:
   enabled: false
   host: ds-policy-engine.uva.nextgen.hiro-develop.nl
 
+# Option B: UI talks to backend same-origin via its nginx proxy — no browser
+# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
+# a knob in case a second UI/client origin ever needs direct access.
 cors:
-  allowedOrigins: "https://ds-policy-engine-ui.uva.nextgen.hiro-develop.nl"
+  allowedOrigins: ""
 
 docs:
   enabled: false

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -4,20 +4,24 @@ nodeSelector:
   role: uva
 
 ingress:
-  # Fully internal — backend reachable only by in-cluster DNS
-  # (ds-policy-engine.uva.svc.cluster.local:8000).
-  enabled: false
+  # TEMP: enabled for now while there's no sensitive data and no shared
+  # gateway yet. Flip to false once ds-gateway fronts the service.
+  enabled: true
   host: ds-policy-engine.uva.nextgen.hiro-develop.nl
 
-# Option B: UI talks to backend same-origin via its nginx proxy — no browser
-# ever hits this backend directly, so no CORS allowlist needed. Kept empty as
-# a knob in case a second UI/client origin ever needs direct access.
+# With Option B the UI calls the backend same-origin through its nginx proxy,
+# so no browser ever hits this backend directly and CORS is not needed.
 cors:
   allowedOrigins: ""
 
+# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
+# Flip to true on dev sites if you want to poke the API from a browser.
 docs:
   enabled: false
 
+# OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
+# and evaluates the compiled Rego rules at request time. Keep on — the
+# backend depends on it.
 opa:
   enabled: true
 
@@ -27,4 +31,4 @@ persistence:
 
 env:
   logLevel: INFO
-  nodeName: uva
+  # DS__NODE_NAME intentionally omitted — chart defaults it to the namespace.

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -4,6 +4,9 @@ nodeSelector:
   role: uva
 
 ingress:
+  # Fully internal — backend reachable only by in-cluster DNS
+  # (ds-policy-engine.uva.svc.cluster.local:8000).
+  enabled: false
   host: ds-policy-engine.uva.nextgen.hiro-develop.nl
 
 cors:


### PR DESCRIPTION
- ki-services/policy-engine/ + policy-engine-ui/
- hus-services/policy-engine/ + policy-engine-ui/
- uva-services/policy-engine/ + policy-engine-ui/

Each folder has fleet.yaml (placeholder chart version — update after first ds-policy-engine / ds-policy-engine-ui CI publishes to gh-pages) and site-specific values.yaml (ingress host, namespace, nodeSelector, CORS allowlist / apiBaseUrl wiring).

UI depends on its same-site backend via dependsOn for ordered rollout.

Appended two service entries to README.md.