### PR TITLE
Bump ds-policy-engine + ds-policy-engine-ui to main-tagged charts

### DIFF
--- a/hus-services/policy-engine-ui/fleet.yaml
+++ b/hus-services/policy-engine-ui/fleet.yaml
@@ -6,6 +6,6 @@ helm:
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
   # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
-  version: 0.1.0-dev.11.develop.3c2ccdb0
+  version: 0.1.0-dev.12.main.c2d11c84
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.31.develop.2274bc55
+  version: 0.1.0-dev.32.main.4e830254
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine-ui/fleet.yaml
+++ b/ki-services/policy-engine-ui/fleet.yaml
@@ -8,6 +8,6 @@ helm:
   # Exact pin — Fleet only rolls out when this string changes. Bump deliberately
   # when promoting a new UI build (grab from
   # https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts/index.yaml).
-  version: 0.1.0-dev.11.develop.3c2ccdb0
+  version: 0.1.0-dev.12.main.c2d11c84
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -7,6 +7,6 @@ helm:
   # when promoting a new build to this site (grab the version from
   # https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts/index.yaml
   # or https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine/releases).
-  version: 0.1.0-dev.31.develop.2274bc55
+  version: 0.1.0-dev.32.main.4e830254
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine-ui/fleet.yaml
+++ b/uva-services/policy-engine-ui/fleet.yaml
@@ -6,6 +6,6 @@ helm:
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
   # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
-  version: 0.1.0-dev.11.develop.3c2ccdb0
+  version: 0.1.0-dev.12.main.c2d11c84
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.31.develop.2274bc55
+  version: 0.1.0-dev.32.main.4e830254
   valuesFiles:
     - values.yaml


### PR DESCRIPTION
Follow-up to merged PR #8.

Both source repos (ds-policy-engine and ds-policy-engine-ui) had their
develop->main PRs merged. CI on the merge commits published new
main-tagged Helm charts. This PR bumps the gitops pins so Fleet rolls
ki/hus/uva onto the merged-state charts.

| File | From | To |
|------|------|-----|
| {ki,hus,uva}-services/policy-engine/fleet.yaml | 0.1.0-dev.31.develop.2274bc55 | 0.1.0-dev.32.main.4e830254 |
| {ki,hus,uva}-services/policy-engine-ui/fleet.yaml | 0.1.0-dev.11.develop.3c2ccdb0 | 0.1.0-dev.12.main.c2d11c84 |

After merge, Fleet syncs and rolls out the new images on its next pass
(usually 1-5 min interval).

Note: the stuck pod in uva is also being blocked by a Harvester
hot-plug volume readiness issue — separate from this version bump.
Restarting the pod after the rollout should resolve both.