### PR TITLE
Bump pins to main-tagged charts including Recreate + cert-manager TLS

### DIFF
--- a/hus-services/policy-engine-ui/fleet.yaml
+++ b/hus-services/policy-engine-ui/fleet.yaml
@@ -6,6 +6,6 @@ helm:
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
   # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
-  version: 0.1.0-dev.12.main.c2d11c84
+  version: 0.1.0-dev.14.main.01f9219f
   valuesFiles:
     - values.yaml

--- a/hus-services/policy-engine/fleet.yaml
+++ b/hus-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.32.main.4e830254
+  version: 0.1.0-dev.35.main.3a11d6c1
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine-ui/fleet.yaml
+++ b/ki-services/policy-engine-ui/fleet.yaml
@@ -8,6 +8,6 @@ helm:
   # Exact pin — Fleet only rolls out when this string changes. Bump deliberately
   # when promoting a new UI build (grab from
   # https://hiro-microdatacenters-bv.github.io/ds-policy-engine-ui/helm-charts/index.yaml).
-  version: 0.1.0-dev.12.main.c2d11c84
+  version: 0.1.0-dev.14.main.01f9219f
   valuesFiles:
     - values.yaml

--- a/ki-services/policy-engine/fleet.yaml
+++ b/ki-services/policy-engine/fleet.yaml
@@ -7,6 +7,6 @@ helm:
   # when promoting a new build to this site (grab the version from
   # https://hiro-microdatacenters-bv.github.io/ds-policy-engine/helm-charts/index.yaml
   # or https://github.com/HIRO-MicroDataCenters-BV/ds-policy-engine/releases).
-  version: 0.1.0-dev.32.main.4e830254
+  version: 0.1.0-dev.35.main.3a11d6c1
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine-ui/fleet.yaml
+++ b/uva-services/policy-engine-ui/fleet.yaml
@@ -6,6 +6,6 @@ helm:
   chart: ds-policy-engine-ui
   releaseName: ds-policy-engine-ui
   # Exact pin — see ki-services/policy-engine-ui/fleet.yaml for how to bump.
-  version: 0.1.0-dev.12.main.c2d11c84
+  version: 0.1.0-dev.14.main.01f9219f
   valuesFiles:
     - values.yaml

--- a/uva-services/policy-engine/fleet.yaml
+++ b/uva-services/policy-engine/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   chart: ds-policy-engine
   releaseName: ds-policy-engine
   # Exact pin — see ki-services/policy-engine/fleet.yaml for how to bump.
-  version: 0.1.0-dev.32.main.4e830254
+  version: 0.1.0-dev.35.main.3a11d6c1
   valuesFiles:
     - values.yaml


### PR DESCRIPTION
This pull request updates the Helm chart versions for both the `ds-policy-engine` and `ds-policy-engine-ui` services across multiple environments to deploy the latest builds. These changes ensure that all environments are using consistent and up-to-date versions of the policy engine and its UI.

**Policy Engine version bumps:**
* Updated the `ds-policy-engine` Helm chart version from `0.1.0-dev.32.main.4e830254` to `0.1.0-dev.35.main.3a11d6c1` in the following files:
  - `ki-services/policy-engine/fleet.yaml`
  - `uva-services/policy-engine/fleet.yaml`
  - `hus-services/policy-engine/fleet.yaml`

**Policy Engine UI version bumps:**
* Updated the `ds-policy-engine-ui` Helm chart version from `0.1.0-dev.12.main.c2d11c84` to `0.1.0-dev.14.main.01f9219f` in the following files:
  - `ki-services/policy-engine-ui/fleet.yaml`
  - `uva-services/policy-engine-ui/fleet.yaml`
  - `hus-services/policy-engine-ui/fleet.yaml`- Backend: 0.1.0-dev.32.main.4e830254 -> 0.1.0-dev.35.main.3a11d6c1 Picks up: Deployment.spec.strategy=Recreate (resolves RWO PVC handover deadlock that was leaving two ReplicaSets stuck), cert-manager Ingress (cluster-issuer letsencrypt-prod, secretName ds-policy-engine-tls-secret), ingressClassName=nginx so the cluster controller actually claims it.

- UI: 0.1.0-dev.12.main.c2d11c84 -> 0.1.0-dev.14.main.01f9219f Picks up: cert-manager Ingress (secretName ds-policy-engine-ui-tls-secret), ingressClassName=nginx, Ingress resource name suffix '-ingress' for parity with the rest of the org (ds-search-ingress, ds-catalog-ingress, etc.).

Per-site values.yaml in this repo unchanged — chart defaults already carry the right cluster-issuer + secretName + className. Only the host varies per site, which is already overridden.