### PR TITLE
Re-enable /docs on policy-engine across all sites

### DIFF
--- a/hus-services/policy-engine/values.yaml
+++ b/hus-services/policy-engine/values.yaml
@@ -14,10 +14,11 @@ ingress:
 cors:
   allowedOrigins: ""
 
-# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
-# Flip to true on dev sites if you want to poke the API from a browser.
+# Swagger UI is on by default — /docs, /redoc, /openapi.json are reachable.
+# Will be flipped off explicitly later (e.g. once ds-gateway fronts the service
+# or the API surface goes sensitive). Until then, leave on.
 docs:
-  enabled: false
+  enabled: true
 
 # OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
 # and evaluates the compiled Rego rules at request time. Keep on — the

--- a/ki-services/policy-engine/values.yaml
+++ b/ki-services/policy-engine/values.yaml
@@ -16,10 +16,11 @@ ingress:
 cors:
   allowedOrigins: ""
 
-# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
-# Flip to true on dev sites if you want to poke the API from a browser.
+# Swagger UI is on by default — /docs, /redoc, /openapi.json are reachable.
+# Will be flipped off explicitly later (e.g. once ds-gateway fronts the service
+# or the API surface goes sensitive). Until then, leave on.
 docs:
-  enabled: false
+  enabled: true
 
 # OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
 # and evaluates the compiled Rego rules at request time. Keep on — the

--- a/uva-services/policy-engine/values.yaml
+++ b/uva-services/policy-engine/values.yaml
@@ -14,10 +14,11 @@ ingress:
 cors:
   allowedOrigins: ""
 
-# Disable Swagger UI in production (hides /docs, /redoc, /openapi.json).
-# Flip to true on dev sites if you want to poke the API from a browser.
+# Swagger UI is on by default — /docs, /redoc, /openapi.json are reachable.
+# Will be flipped off explicitly later (e.g. once ds-gateway fronts the service
+# or the API surface goes sensitive). Until then, leave on.
 docs:
-  enabled: false
+  enabled: true
 
 # OPA (Open Policy Agent) runs as a sidecar inside the policy-engine pod
 # and evaluates the compiled Rego rules at request time. Keep on — the


### PR DESCRIPTION
## Summary
- Flip `docs.enabled` from `false` to `true` in ki/hus/uva policy-engine values
- Earlier review had hidden Swagger as a prod hygiene step; the API is still small/internal and we want `/docs`, `/redoc`, `/openapi.json` reachable for now
- Will be turned off explicitly later (e.g. once ds-gateway fronts the service)

## Test plan
- [ ] Fleet syncs the bundle on all three sites (ki/hus/uva)
- [ ] `https://ds-policy-engine-ui.<site>.nextgen.hiro-develop.nl/api/docs` returns Swagger UI (not 404)
- [ ] Backend deployment env shows `DS__DOCS_ENABLED=true`